### PR TITLE
Allow regex to work with spaces in operators

### DIFF
--- a/tla_repl.py
+++ b/tla_repl.py
@@ -45,7 +45,7 @@ class TLARepl(cmd.Cmd):
             # See if this is a new definition i.e. something like 'var == {1,2,3}'
             # In that case, don't evaluate it, just add it to the context. Note that
             # '\S' in a regex matches any non whitespace character.
-            regex = "(?P<def>\S+)( )?==.*"
+            regex = "(?P<def>.*?)\W*==.*"
             m = re.match(regex, expr)
             if m:
                 # Overwrite an existing definition if there is a name conflict.


### PR DESCRIPTION
I got tripped up because I was writing my operators with spaces which the regex in tla_repl.py didn't like.


After some troubleshooting I determined that the following would work:

```
Sum(a,b) == a+b
```


But these would not because of whitespace:
```
Sum(a, b) == a+b
```
```
Sum(a, b)     == a+b
```

This PR changes the regex to perform a non-greedy search up to ==.


ps- I have found tlaplus_repl to be extremely helpful for getting my feet wet with TLA+. It is light-years better than evaluate constant expression.
